### PR TITLE
Allow ordering of results

### DIFF
--- a/openapi/__init__.py
+++ b/openapi/__init__.py
@@ -1,4 +1,4 @@
 """Minimal OpenAPI asynchronous server application
 """
 
-__version__ = '0.5.4'
+__version__ = '0.6.0'

--- a/openapi/data/fields.py
+++ b/openapi/data/fields.py
@@ -262,6 +262,15 @@ class NumberValidator(Validator):
             prop['maximum'] = self.max_value
 
 
+class IntegerValidator(NumberValidator):
+    def __call__(self, field, value, data=None):
+        try:
+            value = int(value)
+        except (ValueError, TypeError):
+            raise ValidationError(field.name, '%s not valid integer' % value)
+        return super().__call__(field, value, data=data)
+
+
 class DecimalValidator(NumberValidator):
     def __call__(self, field, value, data=None):
         try:

--- a/openapi/data/fields.py
+++ b/openapi/data/fields.py
@@ -234,11 +234,16 @@ class DateTimeValidator(Validator):
 
 class NumberValidator(Validator):
 
-    def __init__(self, min_value=None, max_value=None):
+    def __init__(self, min_value=None, max_value=None, precision=None):
         self.min_value = min_value
         self.max_value = max_value
+        self.precision = precision
 
     def __call__(self, field, value, data=None):
+        try:
+            value = round(value, self.precision)
+        except (ValueError, TypeError):
+            raise ValidationError(field.name, '%s not valid number' % value)
         if self.min_value is not None and value < self.min_value:
             raise ValidationError(field.name, '%s less than %s'
                                   % (value, self.min_value))
@@ -248,7 +253,7 @@ class NumberValidator(Validator):
         return value
 
     def dump(self, value):
-        return value
+        return round(value, self.precision)
 
     def openapi(self, prop):
         if self.min_value is not None:
@@ -267,21 +272,12 @@ class IntegerValidator(NumberValidator):
 
 
 class DecimalValidator(NumberValidator):
-    def __init__(self, min_value=None, max_value=None, precision=None):
-        super().__init__(min_value=min_value, max_value=max_value)
-        self.precision = precision
-
     def __call__(self, field, value, data=None):
         try:
             value = decimal.Decimal(value)
-            value = round(value, self.precision)
-        except (TypeError, ValueError, decimal.InvalidOperation):
+        except (TypeError, decimal.InvalidOperation):
             raise ValidationError(field.name, '%s not valid Decimal' % value)
-
         return super().__call__(field, value, data=None)
-
-    def dump(self, value):
-        return round(value, self.precision)
 
 
 class BoolValidator(Validator):

--- a/openapi/data/fields.py
+++ b/openapi/data/fields.py
@@ -274,13 +274,9 @@ class DecimalValidator(NumberValidator):
     def __call__(self, field, value, data=None):
         try:
             value = decimal.Decimal(value)
-        except (TypeError, decimal.InvalidOperation):
-            raise ValidationError(field.name, '%s not valid Decimal' % value)
-
-        try:
             value = round(value, self.precision)
-        except (ValueError, TypeError):
-            raise ValidationError(field.name, '%s not valid number' % value)
+        except (TypeError, ValueError, decimal.InvalidOperation):
+            raise ValidationError(field.name, '%s not valid Decimal' % value)
 
         return super().__call__(field, value, data=None)
 

--- a/openapi/data/fields.py
+++ b/openapi/data/fields.py
@@ -76,6 +76,12 @@ def number_field(min_value=None, max_value=None, precision=None, **kw):
     return data_field(**kw)
 
 
+def integer_field(min_value=None, max_value=None, **kw):
+    kw.setdefault(
+        'validator', IntegerValidator(min_value, max_value))
+    return data_field(**kw)
+
+
 def decimal_field(min_value=None, max_value=None, precision=None, **kw):
     kw.setdefault(
         'validator', DecimalValidator(min_value, max_value, precision))
@@ -232,18 +238,12 @@ class DateTimeValidator(Validator):
         return value
 
 
-class NumberValidator(Validator):
-
-    def __init__(self, min_value=None, max_value=None, precision=None):
+class BoundedNumberValidator(Validator):
+    def __init__(self, min_value=None, max_value=None):
         self.min_value = min_value
         self.max_value = max_value
-        self.precision = precision
 
     def __call__(self, field, value, data=None):
-        try:
-            value = round(value, self.precision)
-        except (ValueError, TypeError):
-            raise ValidationError(field.name, '%s not valid number' % value)
         if self.min_value is not None and value < self.min_value:
             raise ValidationError(field.name, '%s less than %s'
                                   % (value, self.min_value))
@@ -253,7 +253,7 @@ class NumberValidator(Validator):
         return value
 
     def dump(self, value):
-        return round(value, self.precision)
+        return value
 
     def openapi(self, prop):
         if self.min_value is not None:
@@ -262,9 +262,28 @@ class NumberValidator(Validator):
             prop['maximum'] = self.max_value
 
 
-class IntegerValidator(NumberValidator):
+class NumberValidator(BoundedNumberValidator):
+
+    def __init__(self, min_value=None, max_value=None, precision=None):
+        super().__init__(min_value=min_value, max_value=max_value)
+        self.precision = precision
+
     def __call__(self, field, value, data=None):
         try:
+            value = round(value, self.precision)
+        except (ValueError, TypeError):
+            raise ValidationError(field.name, '%s not valid number' % value)
+        return super().__call__(field, value, data=data)
+
+    def dump(self, value):
+        return round(value, self.precision)
+
+
+class IntegerValidator(BoundedNumberValidator):
+    def __call__(self, field, value, data=None):
+        try:
+            if isinstance(value, float):
+                raise ValueError
             value = int(value)
         except (ValueError, TypeError):
             raise ValidationError(field.name, '%s not valid integer' % value)

--- a/openapi/db/path.py
+++ b/openapi/db/path.py
@@ -2,7 +2,7 @@ import re
 
 from aiohttp import web
 from asyncpg.exceptions import UniqueViolationError
-from sqlalchemy.sql import and_
+from sqlalchemy.sql import and_, Select
 
 from .compile import compile_query
 from ..spec.pagination import DEF_PAGINATION_LIMIT
@@ -211,12 +211,13 @@ class SqlApiPath(ApiPath):
             filters = and_(*filters) if len(filters) > 1 else filters[0]
             query = query.where(filters)
 
-        # ordering
-        query = self.get_order_clause(table, query, order_by, order_desc)
+        if isinstance(query, Select):
+            # ordering
+            query = self.get_order_clause(table, query, order_by, order_desc)
 
-        # pagination
-        query = query.offset(offset)
-        query = query.limit(limit)
+            # pagination
+            query = query.offset(offset)
+            query = query.limit(limit)
 
         return query
 

--- a/openapi/rest.py
+++ b/openapi/rest.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 
-from .spec import OpenApi
+from openapi.data.fields import Choice, IntegerValidator
 from .cli import OpenApiClient
-from .data.fields import data_field, NumberValidator
+from .data.fields import data_field, bool_field
+from .spec import OpenApi
 from .spec.pagination import MAX_PAGINATION_LIMIT
 
 
@@ -18,13 +19,31 @@ def rest(setup_app=None, base_path=None, commands=None, **kwargs):
 @dataclass
 class Query:
     limit: int = data_field(
-        validator=NumberValidator(min_value=1, max_value=MAX_PAGINATION_LIMIT),
+        validator=IntegerValidator(min_value=1,
+                                   max_value=MAX_PAGINATION_LIMIT),
         description='Limit the number of objects returned from the endpoint'
     )
     offset: int = data_field(
-        validator=NumberValidator(min_value=0),
+        validator=IntegerValidator(min_value=0),
         description=(
             'Number of objects to exclude. '
             'Use in conjunction with limit to paginate results'
         )
     )
+
+
+def orderable(*orderable_fields):
+    @dataclass
+    class Orderable:
+        order_by: str = data_field(
+            validator=Choice(orderable_fields),
+            description=(
+                'Order results by given column (default ascending order)'
+            )
+        )
+        order_desc: bool = bool_field(
+            description=(
+                'Change order direction to descending'
+            )
+        )
+    return Orderable

--- a/openapi/rest.py
+++ b/openapi/rest.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from openapi.data.fields import Choice, IntegerValidator
+from .data.fields import Choice, IntegerValidator
 from .cli import OpenApiClient
 from .data.fields import data_field, bool_field
 from .spec import OpenApi

--- a/tests/data/test_fields.py
+++ b/tests/data/test_fields.py
@@ -6,10 +6,10 @@ from decimal import Decimal
 
 from openapi.data.fields import (
     ValidationError, data_field, bool_field, uuid_field, number_field,
-    decimal_field, email_field, enum_field, date_time_field,  json_field,
+    decimal_field, email_field, enum_field, date_time_field, json_field,
     ListValidator, UUIDValidator, EnumValidator, Choice, DateTimeValidator,
     NumberValidator, DecimalValidator, email_validator, BoolValidator,
-    Validator, JSONValidator
+    Validator, JSONValidator, IntegerValidator,
 )
 
 
@@ -155,6 +155,33 @@ def test_NumberValidator_dump():
     assert validator.dump(-10) == -10
     assert validator.dump(5.55) == 5.55
     assert validator.dump(5.556) == 5.56
+
+
+def test_IntegerValidator_valid():
+    field = number_field()
+    validator = IntegerValidator(min_value=-10, max_value=10)
+    assert validator(field, 10) == 10
+    assert validator(field, 0) == 0
+    assert validator(field, -10) == -10
+    assert validator(field, '-5') == -5
+
+
+def test_IntegerValidator_invalid():
+    field = number_field()
+    validator = IntegerValidator(min_value=-10, max_value=10)
+    with pytest.raises(ValidationError):
+        validator(field, 11)
+    with pytest.raises(ValidationError):
+        validator(field, -11)
+    with pytest.raises(ValidationError):
+        validator(field, -1.12)
+
+
+def test_IntegerValidator_dump():
+    validator = IntegerValidator(min_value=-10, max_value=10)
+    assert validator.dump(10) == 10
+    assert validator.dump(0) == 0
+    assert validator.dump(-10) == -10
 
 
 def test_DecimalValidator_valid():

--- a/tests/example/db.py
+++ b/tests/example/db.py
@@ -30,7 +30,8 @@ def meta(meta=None):
         sa.Column('done', sa.DateTime),
         sa.Column('severity', sa.Integer),
         sa.Column('type', sa.Enum(TaskType)),
-        sa.Column('unique_title', sa.String, nullable=True, unique=True)
+        sa.Column('unique_title', sa.String, nullable=True, unique=True),
+        sa.Column('story_points', sa.Numeric(2))
     )
 
     sa.Table(

--- a/tests/example/endpoints.py
+++ b/tests/example/endpoints.py
@@ -6,7 +6,8 @@ from openapi.db.path import SqlApiPath
 from openapi.spec import op
 from openapi.exc import JsonHttpException
 from .models import (
-    Task, TaskAdd, TaskQuery, TaskPathSchema, TaskUpdate, TaskPathSchema2
+    Task, TaskAdd, TaskQuery, TaskPathSchema, TaskUpdate, TaskPathSchema2,
+    TaskOrderableQuery,
 )
 
 
@@ -27,7 +28,7 @@ class TasksPath(SqlApiPath):
         done = self.db_table.c.done
         return done != null() if value else done == null()
 
-    @op(query_schema=TaskQuery, response_schema=[Task])
+    @op(query_schema=TaskOrderableQuery, response_schema=[Task])
     async def get(self):
         """
         ---
@@ -162,7 +163,7 @@ class TaskTransactionsPath(SqlApiPath):
 
                 return self.json_response(data=task, status=201)
 
-    @op(query_schema=TaskQuery, response_schema=[Task])
+    @op(query_schema=TaskOrderableQuery, response_schema=[Task])
     async def get(self):
         """
         ---

--- a/tests/example/models.py
+++ b/tests/example/models.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from openapi.data.fields import (
     data_field, date_time_field, decimal_field, enum_field
 )
+from openapi.rest import orderable, Query
 
 
 class TaskType(enum.Enum):
@@ -34,9 +35,15 @@ class Task(TaskAdd):
 
 @dataclass
 class TaskQuery:
+    title: str = data_field()
     done: bool = data_field()
     type: TaskType = enum_field(TaskType)
     severity: int = decimal_field(ops=('lt', 'le', 'gt', 'ge', 'ne'))
+
+
+@dataclass
+class TaskOrderableQuery(TaskQuery, orderable('title'), Query):
+    pass
 
 
 @dataclass

--- a/tests/example/models.py
+++ b/tests/example/models.py
@@ -1,10 +1,13 @@
 import enum
 from datetime import datetime
+from decimal import Decimal
 
 from dataclasses import dataclass
 
 from openapi.data.fields import (
-    data_field, date_time_field, decimal_field, enum_field
+    data_field, date_time_field, enum_field,
+    integer_field,
+    decimal_field,
 )
 from openapi.rest import orderable, Query
 
@@ -17,9 +20,10 @@ class TaskType(enum.Enum):
 @dataclass
 class TaskAdd:
     title: str = data_field(required=True)
-    severity: int = decimal_field()
+    severity: int = integer_field()
     type: TaskType = enum_field(TaskType, default=TaskType.todo)
     unique_title: str = data_field()
+    story_points: Decimal = decimal_field(default=0.0)
 
     @classmethod
     def validate(cls, data, errors):
@@ -31,6 +35,7 @@ class TaskAdd:
 class Task(TaskAdd):
     id: int = data_field(required=True)
     done: datetime = date_time_field()
+    story_points: Decimal = decimal_field()
 
 
 @dataclass
@@ -38,7 +43,8 @@ class TaskQuery:
     title: str = data_field()
     done: bool = data_field()
     type: TaskType = enum_field(TaskType)
-    severity: int = decimal_field(ops=('lt', 'le', 'gt', 'ge', 'ne'))
+    severity: int = integer_field(ops=('lt', 'le', 'gt', 'ge', 'ne'))
+    story_points: Decimal = decimal_field()
 
 
 @dataclass

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -12,6 +12,7 @@ async def test_spec(test_app):
     query = spec.paths['/tasks']['get']['parameters']
     filters = [q['name'] for q in query]
     assert set(filters) == {
+        'title',
         'done',
         'type',
         'severity',
@@ -20,6 +21,10 @@ async def test_spec(test_app):
         'severity:gt',
         'severity:ge',
         'severity:ne',
+        'order_by',
+        'order_desc',
+        'limit',
+        'offset',
     }
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -21,6 +21,7 @@ async def test_spec(test_app):
         'severity:gt',
         'severity:ge',
         'severity:ne',
+        'story_points',
         'order_by',
         'order_desc',
         'limit',


### PR DESCRIPTION
Closes #74

Allows queries to specify SQL `ORDER BY (DESC)`.

Fix a bug in using `limit` and `offset`. Failed when parsing the
limit/offset from JSON as we'd end up with a string. Added an
IntegerValidator to coerce this to int.