### PR TITLE
Changing allowed_tasks configuration

### DIFF
--- a/openapi/spec/spec.py
+++ b/openapi/spec/spec.py
@@ -45,6 +45,7 @@ class OpenApi:
     security: Dict[str, Dict] = field(default_factory=dict)
     contact: Contact = Contact()
     license: License = License()
+    allowed_tags: set = None
 
 
 class SchemaParser:
@@ -181,7 +182,7 @@ class OpenApiSpec:
     """Open API document builder
     """
     def __init__(self, info, default_content_type=None,
-                 default_responses=None, allowed_tags=None):
+                 default_responses=None):
         self.schemas = {}
         self.parameters = {}
         self.responses = {}
@@ -196,7 +197,7 @@ class OpenApiSpec:
             paths=OrderedDict()
         )
         self.schemas_to_parse = set()
-        self.allowed_tags = allowed_tags
+        self.allowed_tags = info.pop('allowed_tags', None)
 
     @property
     def paths(self):

--- a/tests/spec/test_spec.py
+++ b/tests/spec/test_spec.py
@@ -89,21 +89,15 @@ async def test_invalid_method_missing_description():
 
 async def test_allowed_tags_ok():
     app = create_spec_app(endpoints.routes)
-    open_api = OpenApi()
-    spec = OpenApiSpec(
-        asdict(open_api),
-        allowed_tags=set(('Task', 'Transaction', 'Random'))
-    )
+    open_api = OpenApi(allowed_tags=set(('Task', 'Transaction', 'Random')))
+    spec = OpenApiSpec(asdict(open_api))
     spec.build(app)
 
 
 async def test_allowed_tags_invalid():
     app = create_spec_app(endpoints.routes)
-    open_api = OpenApi()
-    spec = OpenApiSpec(
-        asdict(open_api),
-        allowed_tags=set(('Task', 'Transaction'))
-    )
+    open_api = OpenApi(allowed_tags=set(('Task', 'Transaction')))
+    spec = OpenApiSpec(asdict(open_api))
     with pytest.raises(InvalidSpecException):
         spec.build(app)
 
@@ -111,9 +105,6 @@ async def test_allowed_tags_invalid():
 async def test_tags_missing_description():
     app = create_spec_app(endpoints.invalid_tag_missing_description_routes)
     open_api = OpenApi()
-    spec = OpenApiSpec(
-        asdict(open_api),
-        allowed_tags=set(('Task', 'Transaction', 'Random'))
-    )
+    spec = OpenApiSpec(asdict(open_api))
     with pytest.raises(InvalidSpecException):
         spec.build(app)


### PR DESCRIPTION
I had to put the `allowed_tags` into the OpenAPI dataclass because it's the only way to configure the builder outside openapi