### PR TITLE
Fix numerical validators with precision=None

### DIFF
--- a/openapi/__init__.py
+++ b/openapi/__init__.py
@@ -1,4 +1,4 @@
 """Minimal OpenAPI asynchronous server application
 """
 
-__version__ = '0.8.3'
+__version__ = '0.8.4'

--- a/openapi/data/fields.py
+++ b/openapi/data/fields.py
@@ -354,7 +354,9 @@ class IntegerValidator(BoundedNumberValidator):
 class DecimalValidator(NumberValidator):
     def __call__(self, field, value, data=None):
         try:
-            value = decimal.Decimal(str(value))
+            if isinstance(value, float):
+                value = str(value)
+            value = decimal.Decimal(value)
         except (TypeError, decimal.InvalidOperation):
             raise ValidationError(field.name, '%s not valid Decimal' % value)
         return super().__call__(field, value, data=None)

--- a/tests/data/test_fields.py
+++ b/tests/data/test_fields.py
@@ -190,9 +190,17 @@ def test_DecimalValidator_valid():
     assert validator(field, 10) == 10
     assert validator(field, -10) == -10
     assert validator(field, 5.55) == Decimal('5.55')
-    # assert validator(field, 5.555) == Decimal(5.55)
-    # assert validator(field, '5.555') == Decimal(5.55)
-    # assert validator(field, (5, 555)) == Decimal(5.55)
+    assert validator(field, 5.555) == Decimal('5.56')
+    assert validator(field, '5.555') == Decimal('5.56')
+
+
+def test_DecimalValidator_precision_None():
+    field = decimal_field()
+    validator = DecimalValidator(min_value=-10, max_value=10)
+    assert validator(field, 10) == 10
+    assert validator(field, -10) == -10
+    assert validator(field, 5.555) == Decimal('5.555')
+    assert validator(field, 5.555555555555555) == Decimal('5.555555555555555')
 
 
 def test_DecimalValidator_invalid():
@@ -208,10 +216,10 @@ def test_DecimalValidator_invalid():
 
 def test_DecimalValidator_dump():
     validator = DecimalValidator(min_value=-10, max_value=10, precision=2)
-    assert validator.dump(10) == 10
-    assert validator.dump(-10) == -10
-    assert validator.dump(5.55) == 5.55
-    assert validator.dump(5.556) == 5.56
+    assert validator.dump(Decimal(10)) == Decimal('10')
+    assert validator.dump(Decimal(-10)) == Decimal('-10')
+    assert validator.dump(Decimal('5.55')) == Decimal('5.55')
+    assert validator.dump(Decimal('5.556')) == Decimal('5.56')
 
 
 def test_email_validator_valid():

--- a/tests/example/endpoints.py
+++ b/tests/example/endpoints.py
@@ -44,7 +44,7 @@ class TasksPath(SqlApiPath):
                 description: Authenticated tasks
         """
         data = await self.get_list()
-        return web.json_response(data)
+        return self.json_response(data)
 
     @op(response_schema=Task, body_schema=TaskAdd)
     async def post(self):
@@ -59,7 +59,7 @@ class TasksPath(SqlApiPath):
                 description: Failed validation
         """
         data = await self.create_one()
-        return web.json_response(data, status=201)
+        return self.json_response(data, status=201)
 
     @op(query_schema=TaskQuery)
     async def delete(self):


### PR DESCRIPTION
If precision is None, then I believe the sensible behaviour is not to
apply a `round`, but to instead maintain the precision of the given
value.

This change corrects the base class to apply round only in the
circumstance that precision is not None. Also true when using
`Validator.dump`.