### PR TITLE
use full_url method in ApiPath

### DIFF
--- a/openapi/__init__.py
+++ b/openapi/__init__.py
@@ -1,4 +1,4 @@
 """Minimal OpenAPI asynchronous server application
 """
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/openapi/db/path.py
+++ b/openapi/db/path.py
@@ -94,7 +94,7 @@ class SqlApiPath(ApiPath):
         async with self.db.ensure_connection(conn) as conn:
             total = await conn.fetchrow(sql_count, *args_count)
             values = await conn.fetch(sql, *args)
-        pagination = Pagination(self.request.url)
+        pagination = Pagination(self.full_url())
         data = self.dump(dump_schema, values)
         return pagination.paginated(
             data, total['tbl_row_count'], offset, limit

--- a/openapi/spec/hdrs.py
+++ b/openapi/spec/hdrs.py
@@ -1,0 +1,5 @@
+from multidict import istr
+
+X_FORWARDED_PROTO = istr('X-Forwarded-Proto')
+X_FORWARDED_HOST = istr('X-Forwarded-Host')
+X_FORWARDED_PORT = istr('X-Forwarded-Port')


### PR DESCRIPTION
Required for building correct url when served behind nginx